### PR TITLE
Update moderation.py

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -143,10 +143,15 @@ class Moderation(commands.Cog):
         if member.top_role > ctx.author.top_role:
             raise ModError(
                 "You can't kick them, They have higher role than you.")
+        
 
         if member.top_role > ctx.me.top_role:
             raise ModError("I can't kick them, They have higher role than me.")
-
+            
+        if member.top_role == ctx.author.top_role:
+            raise ModError(
+                "I can't kick them, They have same role as me.")
+            
         if member == ctx.me:
             raise ModError("I can't kick myself.")
 
@@ -189,6 +194,10 @@ class Moderation(commands.Cog):
 
         if member.top_role > ctx.me.top_role:
             raise ModError("I can't ban them, They have higher role than me.")
+            
+            if member.top_role == ctx.author.top_role:
+            raise ModError(
+                "I can't ban them, They have same role as me.")
 
         if member == ctx.me:
             raise ModError("I can't ban myself.")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/79563939/148519599-02a06997-2d18-4d88-ab38-8b1cf5bddc14.png)
![image](https://user-images.githubusercontent.com/79563939/148519614-8723ba8e-dc7d-453e-bcb7-a2732046ad8e.png)

What haven't you compared for same role? ( member.top_role == ctx.author.top_role )
Bot cannot kick / ban same highest role members too! 

I have fixed it in my branch, you can check out . 